### PR TITLE
Optimized description(); add createSync(); default naming;.

### DIFF
--- a/Sources/ProgrammaticCoreData/NSManagedObjectModel+Extensions.swift
+++ b/Sources/ProgrammaticCoreData/NSManagedObjectModel+Extensions.swift
@@ -33,6 +33,17 @@ public extension NSManagedObjectModel {
         )
     }
 
+    func createContainerSync(
+        name: String? = nil,
+        location: NSPersistentContainer.Location
+    ) throws -> NSPersistentContainer {
+        try NSPersistentContainer.createSync(
+            name: prefixName(name),
+            model: self,
+            location: location
+        )
+    }
+    
     func createCloudContainer(
         name: String,
         cloudContainerIdentifier: String,
@@ -45,13 +56,13 @@ public extension NSManagedObjectModel {
             options: options
         )
     }
-
-    func createLocalContainer(name: String, path: URL) -> NSPersistentContainer {
-        NSPersistentContainer(name: name, managedObjectModel: self, path: path)
+    
+    func createLocalContainer(name: String? = nil, path: URL) -> NSPersistentContainer {
+        NSPersistentContainer(name: prefixName(name), managedObjectModel: self, path: path)
     }
 
-    func createLocalContainer(name: String, subdirectory: String?) throws -> NSPersistentContainer {
-        try NSPersistentContainer(name: name, managedObjectModel: self, subdirecotry: subdirectory)
+    func createLocalContainer(name: String? = nil, subdirectory: String?) throws -> NSPersistentContainer {
+        try NSPersistentContainer(name: prefixName(name), managedObjectModel: self, subdirecotry: subdirectory)
     }
 
     func createInMemoryContainer(name: String) throws -> NSPersistentContainer {
@@ -61,4 +72,13 @@ public extension NSManagedObjectModel {
         container.persistentStoreDescriptions = [description]
         return container
     }
+
+    /// Be lazy to type names, provide a basically unique prefix for naming.
+    func prefixName(_ name: String?) -> String {
+        if let name = name { name } else {
+            Self.prefix + String(describing: Self.self)
+        }
+    }
+    
+    private static let prefix: String = "ProgrammaticCoreData."
 }

--- a/Sources/ProgrammaticCoreData/SelfDescribingCoreDataEntity+EntityDescription.swift
+++ b/Sources/ProgrammaticCoreData/SelfDescribingCoreDataEntity+EntityDescription.swift
@@ -21,6 +21,19 @@ public extension SelfDescribingCoreDataEntity {
         )
     }
 
+    #if swift(>=5.9)
+    // even more than A24...
+    static func description<each A>(
+        _ parameters: repeat EntityDescriptionAttribute<Self, each A>
+    ) -> NSEntityDescription {
+        var properties: [NSPropertyDescription] = []
+        for para in repeat each parameters {
+            properties.append(para.nsPropertyDescription)
+        }
+        return NSEntityDescription(Self.self, properties: properties)
+    }
+    #endif
+
     static func description<A0, A1, A2>(
         _ a0: EntityDescriptionAttribute<Self, A0>,
         _ a1: EntityDescriptionAttribute<Self, A1>,


### PR DESCRIPTION
### Motivation
1. Models may often meet the situation that count of properties is over 25.
2. Normal call of create() without async context, it was worked in my machine.
3. Avoid annoying Magic-Value naming.